### PR TITLE
Mac readme improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,7 @@
 - ./start.sh
 
 ### macOS
+
+Start by installing `gource`. This can be done using homebrew using `brew install gource`.
+
 on mac you may need to switch sed to gsed in `gource.sh`

--- a/download-repos.sh
+++ b/download-repos.sh
@@ -18,6 +18,6 @@ concurrently \
   "git clone git@github.com:MetaMask/eth-trezor-keyring.git" \
   "git clone git@github.com:MetaMask/eth-ledger-bridge-keyring.git" \
   "git clone git@github.com:MetaMask/eth-sig-util.git" \
-  "git clone git@github.com:MetaMask/eth-json-rpc-middleware.git"
-  "git clone git@github.com:MetaMask/rpc-cap.git" \
+  "git clone git@github.com:MetaMask/eth-json-rpc-middleware.git" \
+  "git clone git@github.com:MetaMask/rpc-cap.git"
 cd ..

--- a/download-repos.sh
+++ b/download-repos.sh
@@ -11,7 +11,13 @@ concurrently \
   "git clone git@github.com:MetaMask/metamask-extension.git" \
   "git clone git@github.com:MetaMask/metamask-mobile.git" \
   "git clone git@github.com:MetaMask/metamask-docs.git" \
+  "git clone git@github.com:MetaMask/controllers.git" \
   "git clone git@github.com:MetaMask/KeyringController.git" \
+  "git clone git@github.com:MetaMask/eth-simple-keyring.git" \
+  "git clone git@github.com:MetaMask/eth-hd-keyring.git" \
+  "git clone git@github.com:MetaMask/eth-trezor-keyring.git" \
+  "git clone git@github.com:MetaMask/eth-ledger-bridge-keyring.git" \
   "git clone git@github.com:MetaMask/eth-sig-util.git" \
   "git clone git@github.com:MetaMask/eth-json-rpc-middleware.git"
+  "git clone git@github.com:MetaMask/rpc-cap.git" \
 cd ..

--- a/start.sh
+++ b/start.sh
@@ -4,6 +4,9 @@ set -e
 set -x
 set -u
 
+# clear previous install
+rm -rf ./repos
+
 # install deps
 ./install-deps.sh
 


### PR DESCRIPTION
Made a few changes:
- Added "install gource" to mac readme section
- Added more repos to the visualization.
- Remove repos folder at the beginning of `start.sh`, since its presence would fail the script.

I also recommend running this with much shorter time per day, but that's just a personal preference. I see it has a way of accepting a start-time, that would also be nice to document.